### PR TITLE
PR: corrected currentTimeMillis

### DIFF
--- a/src/com/tacocardgame/model/Npc.java
+++ b/src/com/tacocardgame/model/Npc.java
@@ -50,7 +50,7 @@ public class Npc extends Player {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         }
-        return System.currentTimeMillis(); // Return the current time after the delay
+        return delay; // Return the current time after the delay
     }
 
     public void setName(String name) {


### PR DESCRIPTION
 since it was using epoch time like 1701693902.46, where the first 6 digits were all the same.  Only the last 4 integers, and two decimal places differed.